### PR TITLE
fix(#407): close the Terminal window a launch leaves behind

### DIFF
--- a/scripts/run-voiceclip.sh
+++ b/scripts/run-voiceclip.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+# Run VoiceClip in the foreground of a Terminal window. Launched by
+# start-via-terminal.sh (login) and by watchdog.sh's relaunch().
+#
+# VoiceClip must be started from Terminal.app: CGEventTap needs Accessibility, which
+# the python process inherits from Terminal (see GOTCHAS.md). The cost is that
+# `do script` always opens a NEW window and Terminal keeps it after the shell exits,
+# so before #407 every launch left a "[Process completed]" corpse behind — and macOS
+# restored each corpse at the next login, so they compounded. 9 dead windows and zero
+# running processes, witnessed 2026-08-31.
+#
+# This script does not close its own window: it cannot. Terminal ignores `close` on a
+# window whose shell is still alive, and once the shell HAS exited there is nothing
+# left in the window to run the close. Reaping is therefore the watchdog's job — see
+# reap_dead_windows() in watchdog.sh. All this script owes it is the marker below.
+
+set -uo pipefail
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+STATE="$HOME/.voice-clip"
+
+mkdir -p "$STATE"
+
+# How the reaper tells our windows apart from Riaan's own. Matching on the title
+# instead would be guesswork: a corpse restored at login is titled plain "-zsh",
+# exactly like every other idle window.
+echo "VOICECLIP-RUNNER-WINDOW"
+
+cd "$DIR" || exit 1
+# stderr redirect is the crash evidence we've never had: deaths so far leave no trace
+# in voiceclip-debug.log, it just stops.
+exec ./venv/bin/python main.py 2>> "$STATE/stderr.log"

--- a/scripts/watchdog.sh
+++ b/scripts/watchdog.sh
@@ -56,16 +56,83 @@ may_relaunch() {
   [ $(( $(date +%s) - $(stat -f %m "$STAMP") )) -ge "$RELAUNCH_COOLDOWN" ]
 }
 
-relaunch() {
-  touch "$STAMP"
-  # stderr redirect is the crash evidence we've never had: deaths so far leave
-  # no trace in voiceclip-debug.log (it just stops).
-  osascript >/dev/null <<EOF
+# Close the Terminal windows our own launches leave behind (#407).
+#
+# Terminal keeps a window after its shell exits, showing "[Process completed]", and
+# macOS restores every one of those at the next login — so they compound. By
+# 2026-08-31 there were 9 corpses and zero running processes.
+#
+# The window cannot close itself: Terminal ignores `close` while the shell is alive,
+# and after the shell exits there is nothing left in the window to run the close. So
+# the reaping lands here, on the 120s poll.
+#
+# Three things this got wrong before and must not get wrong again:
+#
+#   1. `close` is a no-op unless Terminal is activated. Witnessed repeatedly during
+#      #407: the command returns success, no error, and the window stays. So we scan
+#      first WITHOUT activating (reading the window list is fine unfocused) and only
+#      steal focus when there is actually something to close — which, after this fix,
+#      means a login restore or a stop-without-relaunch. Rare, and self-limiting.
+#   2. Never close by an id read earlier. Terminal's window list goes stale within
+#      seconds; during #407 a close aimed at a dead window's id hit the LIVE VoiceClip
+#      window instead and killed the app. Close the object reference from the same
+#      iteration that tested it.
+#   3. `busy is false` is a hard guard, not an optimisation — it is what keeps a
+#      running VoiceClip (or any window Riaan has a process in) out of the loop.
+#
+# The scrollback marker is printed by run-voiceclip.sh. Matching on the title instead
+# would be guesswork: a restored corpse is titled plain "-zsh", like any idle window.
+MARKER="VOICECLIP-RUNNER-WINDOW"
+
+count_dead_windows() {
+  osascript 2>/dev/null <<EOF
 tell application "Terminal"
-    do script "cd '$DIR' && ./venv/bin/python main.py 2>> '$STATE/stderr.log'; exit"
+    set n to 0
+    repeat with w in (every window whose busy is false)
+        try
+            if (history of selected tab of w) contains "$MARKER" then set n to n + 1
+        end try
+    end repeat
+    return n
 end tell
 EOF
 }
+
+reap_dead_windows() {
+  local n
+  n=$(count_dead_windows)
+  [ -n "$n" ] && [ "$n" -gt 0 ] 2>/dev/null || return 0
+
+  log "reaping $n dead VoiceClip Terminal window(s)"
+  osascript >/dev/null 2>&1 <<EOF
+tell application "Terminal"
+    activate
+    delay 0.3
+    repeat with w in (every window whose busy is false)
+        try
+            if (history of selected tab of w) contains "$MARKER" then close w saving no
+        end try
+    end repeat
+end tell
+EOF
+}
+
+relaunch() {
+  touch "$STAMP"
+  # Corpses are cleared here as well as on the poll: `do script` is about to bring
+  # Terminal forward anyway, so the reap's activate costs nothing extra, and a
+  # crash-loop never gets to stack windows up in the first place.
+  reap_dead_windows
+  # The trailing `exit` matters: it ends the shell so the window becomes closeable at
+  # all. Without it the window sits at a live prompt and Terminal refuses to close it.
+  osascript >/dev/null <<EOF
+tell application "Terminal"
+    do script "'$DIR/scripts/run-voiceclip.sh'; exit"
+end tell
+EOF
+}
+
+reap_dead_windows
 
 # --- 1. EXISTENCE ------------------------------------------------------------
 if ! pid=$(running_pid); then

--- a/start-via-terminal.sh
+++ b/start-via-terminal.sh
@@ -1,11 +1,15 @@
 #!/bin/bash
 # Launch VoiceClip via Terminal.app so CGEventTap inherits Accessibility permission.
 # Designed to be called from a LaunchAgent at login.
+#
+# The trailing `exit` ends the shell when VoiceClip stops, which is what makes the
+# window closeable at all — Terminal refuses to close a window whose shell is still
+# alive. The window itself is then closed by the watchdog's reaper (#407).
 
 DIR="$(cd "$(dirname "$0")" && pwd)"
 
 osascript -e "
 tell application \"Terminal\"
-    do script \"cd '$DIR' && ./venv/bin/python main.py; exit\"
+    do script \"'$DIR/scripts/run-voiceclip.sh'; exit\"
 end tell
 "


### PR DESCRIPTION
Fixes the window leak reported in [Riaan-Fourie/Jarvis#407](https://github.com/Riaan-Fourie/Jarvis/issues/407).

## Problem

`start-via-terminal.sh` (login LaunchAgent) and `watchdog.sh`'s `relaunch()` both did `do script "…; exit"`, which always spawns a **new** Terminal window. The shell exited but Terminal kept the window as `[Process completed]`, and macOS's reopen-windows-on-login restored every corpse at each boot — so they compounded. Witnessed 2026-08-31: **9** dead windows, **zero** `main.py` processes.

## Fix

- New `scripts/run-voiceclip.sh` — the single thing both launchers run. Owns the stderr redirect and prints a `VOICECLIP-RUNNER-WINDOW` marker into the scrollback.
- `reap_dead_windows()` in `watchdog.sh` — closes marked, non-busy windows on the 120s poll and at the top of `relaunch()`.

A window cannot close itself: Terminal ignores `close` while the shell is alive, and once the shell has exited there is nothing left in the window to run the close. Hence reaping on the poll.

## Three traps, encoded in comments

1. **`close` is a silent no-op unless Terminal is activated.** Returns success, no error, window stays. The reaper scans unfocused and only activates when there is something to close.
2. **Never close by an id read earlier.** Terminal's window list goes stale within seconds — during this work a close aimed at a dead window's id hit the **live** VoiceClip window and killed the app.
3. **`busy is false` is a hard guard**, not an optimisation — it is what keeps a running VoiceClip, and any window with a process in it, out of the loop.

Terminal launch itself stays: CGEventTap needs Accessibility, which the python process inherits from Terminal.app.

## Witness

```
STEP 0 (baseline):     1 [(626, 'riaanfourie — Python main.py — 80×24')]
STEP 1 (corpse made):  2 [(626, '… Python main.py …'), (649, 'riaanfourie — 80×24')]
--- watchdog run ---
STEP 2 (after reap):   1 [(626, 'riaanfourie — Python main.py — 80×24')]

watchdog.log: 2026-08-31 11:56:22 reaping 1 dead VoiceClip Terminal window(s)
pgrep -fl main.py: 13404 … Python main.py     # live app untouched
```

Window enumeration is via CoreGraphics `CGWindowListCopyWindowInfo`, not Terminal's own list — Terminal's list is the stale one that caused trap 2.

📎 Provenance: Claude Code session a3fb408b-9335-4ed3-8811-70fc03ff77a2

🤖 Generated with [Claude Code](https://claude.com/claude-code)